### PR TITLE
Version lock p5.play

### DIFF
--- a/new_file.txt
+++ b/new_file.txt
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Dodge</title>
+    </head>
+    <body>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.4.12/p5.js"></script>
+        <script src="https://cdn.rawgit.com/molleindustria/p5.play/1bf3c72fe6b647617373b9b3ea3e419baaef8cfd/lib/p5.play.js"></script>
+        <script src="game.js"></script>
+    </body>
+</html>


### PR DESCRIPTION
Hey! I just found an issue on your site and wanted to help fix it:

![](http://i.imgur.com/M2xEkgU.jpg)

It looks like p5.play just updated and broke something on your site. This change sets p5.play to a version before the update which should fix it (and prevent future updates from breaking it).

Just click the "Merge" button down below if you want to accept the changes.